### PR TITLE
Simplify the toolchain installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ install:
         - source $INSTALL_DIR/conda/etc/profile.d/conda.sh
         - conda update -y -q conda
         - wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/4/20200416-002215/symbiflow-arch-defs-install-a321d9d9.tar.xz | tar -xJ -C $INSTALL_DIR
-        - conda install -y -c symbiflow yosys yosys-plugins
-        - conda install -y -c antmicro vtr-no-gui
+        - conda install -y -c symbiflow yosys yosys-plugins vtr-no-gui
         - conda install -y make lxml simplejson intervaltree git pip
         - conda activate
         - pip install python-constraint

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,28 +15,30 @@ before_install:
         - export LANG="en_US.UTF-8"
 
 install:
-        - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-        - bash miniconda.sh -b -p $HOME/miniconda
-        - source "$HOME/miniconda/etc/profile.d/conda.sh"
-        - hash -r
-        - conda config --set always_yes yes --set changeps1 no
-        - conda config --add channels conda-forge
-        - conda config --add channels symbiflow
-        - conda update -q conda
+        - export INSTALL_DIR=/opt/symbiflow
+        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+        - bash Miniconda3-latest-Linux-x86_64.sh -b -p $INSTALL_DIR/conda && rm Miniconda3-latest-Linux-x86_64.sh
+        - source $INSTALL_DIR/conda/etc/profile.d/conda.sh
+        - conda update -y -q conda
+        - wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/4/20200416-002215/symbiflow-arch-defs-install-a321d9d9.tar.xz | tar -xJ -C $INSTALL_DIR
+        - conda install -y -c symbiflow yosys yosys-plugins
+        - conda install -y -c symbiflow -c conda-forge vtr=8.0.0.rc2_3575_g253f75b6d
+        - conda install -y make lxml simplejson intervaltree git pip
         - conda activate
-        - conda install -c symbiflow yosys
-        - conda install -c symbiflow yosys-plugins
-        - conda install -c symbiflow vtr=8.0.0.rc2_3575_g253f75b6d
-        - conda install lxml simplejson intervaltree python-constraint git pip
+        - pip install python-constraint
         - pip install git+https://github.com/symbiflow/fasm
-        - wget "https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/4/20200416-002215/symbiflow-arch-defs-install-a321d9d9.tar.xz"
+        - conda deactivate
 
 script:
-        - tar -xf symbiflow-arch-defs-install-a321d9d9.tar.xz
-        - export PATH=$TRAVIS_BUILD_DIR/install/bin:$PATH
-        - cd $TRAVIS_BUILD_DIR/counter_test
-        - make
-        - cd $TRAVIS_BUILD_DIR/picosoc_demo
-        - make
-        - cd $TRAVIS_BUILD_DIR/linux_litex_demo
-        - make
+        - export INSTALL_DIR=/opt/symbiflow
+        - # adding symbiflow toolchain binaries to PATH
+        - export PATH=$INSTALL_DIR/install/bin:$PATH
+        - source $INSTALL_DIR/conda/etc/profile.d/conda.sh
+        - conda activate
+        - git clone https://github.com/SymbiFlow/symbiflow-examples && cd symbiflow-examples
+        - # counter example
+        - pushd counter_test && make && popd
+        - # picosoc example
+        - pushd picosoc_demo && make && popd
+        - # litex example
+        - pushd linux_litex_demo && make && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
         - conda update -y -q conda
         - wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/4/20200416-002215/symbiflow-arch-defs-install-a321d9d9.tar.xz | tar -xJ -C $INSTALL_DIR
         - conda install -y -c symbiflow yosys yosys-plugins
-        - conda install -y -c symbiflow -c conda-forge vtr=8.0.0.rc2_3575_g253f75b6d
+        - conda install -y -c antmicro vtr-no-gui
         - conda install -y make lxml simplejson intervaltree git pip
         - conda activate
         - pip install python-constraint

--- a/README.md
+++ b/README.md
@@ -45,16 +45,13 @@ INSTALL_DIR=/opt/symbiflow
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -b -p $INSTALL_DIR/conda && rm Miniconda3-latest-Linux-x86_64.sh
 source $INSTALL_DIR/conda/etc/profile.d/conda.sh
-conda config --set always_yes yes --set changeps1 no
-conda config --add channels conda-forge
-conda config --add channels symbiflow
-conda update -q conda
+conda update -y -q conda
 wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/4/20200416-002215/symbiflow-arch-defs-install-a321d9d9.tar.xz | tar -xJ -C $INSTALL_DIR
-conda install -c symbiflow yosys
-conda install -c symbiflow yosys-plugins
-conda install -c symbiflow vtr=8.0.0.rc2_3575_g253f75b6d
-conda install python-constraint make lxml simplejson intervaltree git pip
+conda install -y -c symbiflow yosys yosys-plugins
+conda install -y -c symbiflow -c conda-forge vtr=8.0.0.rc2_3575_g253f75b6d
+conda install -y make lxml simplejson intervaltree git pip
 conda activate
+pip install python-constraint
 pip install git+https://github.com/symbiflow/fasm
 conda deactivate
 ```

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ bash Miniconda3-latest-Linux-x86_64.sh -b -p $INSTALL_DIR/conda && rm Miniconda3
 source $INSTALL_DIR/conda/etc/profile.d/conda.sh
 conda update -y -q conda
 wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/4/20200416-002215/symbiflow-arch-defs-install-a321d9d9.tar.xz | tar -xJ -C $INSTALL_DIR
-conda install -y -c symbiflow yosys yosys-plugins
-conda install -y -c symbiflow -c conda-forge vtr=8.0.0.rc2_3575_g253f75b6d
+conda install -y -c symbiflow yosys yosys-plugins vtr-no-gui
 conda install -y make lxml simplejson intervaltree git pip
 conda activate
 pip install python-constraint


### PR DESCRIPTION
This PR simplifies the toolchain installation procedure. Also we switch to `vpr-no-gui` package, which has way less dependencies than regular `vpr`