### PR TITLE
Add QuickLogic build to tuttest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ jobs:
       script:
             - tuttest README.md unnamed3 | bash -
     - #
-      script:
+      install:
             - tuttest README.md unnamed2 | bash -
+
+      script:
+            - tuttest README.md unnamed4 | bash -
 


### PR DESCRIPTION
This PR adds QL build to the tuttest-based CI. This PR will fail in CI because the guide clones the https://github.com/SymbiFlow/symbiflow-examples repository and builds the examples. The examples are added int #17, so it has to be landed first.

Once #17 is megred this PR will have to be rebased, so it can run the tests from the repository.