### PR TITLE
xc7: fix yosys version

### DIFF
--- a/examples/xc7/environment.yml
+++ b/examples/xc7/environment.yml
@@ -2,7 +2,7 @@ name: xc7
 channels:
   - symbiflow
 dependencies:
-  - symbiflow::symbiflow-yosys
+  - symbiflow::symbiflow-yosys=0.8_3925_g6bccd35a
   - symbiflow::symbiflow-yosys-plugins=1.0.0.7_0032_g104f4fc
   - symbiflow::symbiflow-vtr=8.0.0.rc2_3575_g253f75b6d
   - make


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This is required as the yosys package is updated with the new verison of yosys, which is currently incompatible with the synthesys scripts in the symbiflow installation tarball.