### PR TITLE
Drop CentOS 6 and Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,5 @@ install:
 
 script:
  # Run the tests inside the docker container.
- - if [ "$TOOLCHAIN" = "xc7" ]; then EXTRA_TESTS=,xc7-picosoc,xc7-litex,xc7-linux; fi
+ - if [ "$TOOLCHAIN" = "xc7" ]; then EXTRA_TESTS=,xc7-picosoc; fi
  - tuttest ${TOOLCHAIN}/README.rst ${TOOLCHAIN}-prepare-env,${TOOLCHAIN}-counter${EXTRA_TESTS} | ${IN_DOCKER_EXEC} "$(cat /dev/stdin)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,17 @@ services:
 
 env:
   # Testing QuickLogic toolchain on all OSes
-  - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=trusty
   - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=xenial
   - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=bionic
   - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=eoan
   - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=focal
-  - TOOLCHAIN=eos-s3 OS=centos OS_VERSION=6
   - TOOLCHAIN=eos-s3 OS=centos OS_VERSION=7
   - TOOLCHAIN=eos-s3 OS=centos OS_VERSION=8
   # Testing Xilinx 7 Series toolchain on all OSes
-  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=trusty
   - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=xenial
   - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=bionic
   - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=eoan
   - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=focal
-  - TOOLCHAIN=xc7    OS=centos OS_VERSION=6
   - TOOLCHAIN=xc7    OS=centos OS_VERSION=7
   - TOOLCHAIN=xc7    OS=centos OS_VERSION=8
 


### PR DESCRIPTION
In SymbiFlow scripts we use `realpath` - this tool is not present in CentOS 6 and Ubuntu Trusty. This PR disables tests in those systems.
Also, it temporally disables LiteX xc7 tests. Will reenable them once SymbiFlow support is fixed in upstream LiteX