### PR TITLE
Reenable litex tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,41 @@ services:
 
 env:
   # Testing QuickLogic toolchain on all OSes
-  - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=xenial
-  - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=bionic
-  - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=eoan
-  - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=focal
-  - TOOLCHAIN=eos-s3 OS=centos OS_VERSION=7
-  - TOOLCHAIN=eos-s3 OS=centos OS_VERSION=8
+  - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=xenial  EXAMPLE=eos-s3-counter
+  - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=bionic  EXAMPLE=eos-s3-counter
+  - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=eoan    EXAMPLE=eos-s3-counter
+  - TOOLCHAIN=eos-s3 OS=ubuntu OS_VERSION=focal   EXAMPLE=eos-s3-counter
+  - TOOLCHAIN=eos-s3 OS=centos OS_VERSION=7       EXAMPLE=eos-s3-counter
+  - TOOLCHAIN=eos-s3 OS=centos OS_VERSION=8       EXAMPLE=eos-s3-counter
+
   # Testing Xilinx 7 Series toolchain on all OSes
-  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=xenial
-  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=bionic
-  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=eoan
-  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=focal
-  - TOOLCHAIN=xc7    OS=centos OS_VERSION=7
-  - TOOLCHAIN=xc7    OS=centos OS_VERSION=8
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=xenial  EXAMPLE=xc7-counter
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=bionic  EXAMPLE=xc7-counter
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=eoan    EXAMPLE=xc7-counter
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=focal   EXAMPLE=xc7-counter
+  - TOOLCHAIN=xc7    OS=centos OS_VERSION=7       EXAMPLE=xc7-counter
+  - TOOLCHAIN=xc7    OS=centos OS_VERSION=8       EXAMPLE=xc7-counter
+
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=xenial  EXAMPLE=xc7-picosoc
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=bionic  EXAMPLE=xc7-picosoc
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=eoan    EXAMPLE=xc7-picosoc
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=focal   EXAMPLE=xc7-picosoc
+  - TOOLCHAIN=xc7    OS=centos OS_VERSION=7       EXAMPLE=xc7-picosoc
+  - TOOLCHAIN=xc7    OS=centos OS_VERSION=8       EXAMPLE=xc7-picosoc
+
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=xenial  EXAMPLE=xc7-litex
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=bionic  EXAMPLE=xc7-litex
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=eoan    EXAMPLE=xc7-litex
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=focal   EXAMPLE=xc7-litex
+  - TOOLCHAIN=xc7    OS=centos OS_VERSION=7       EXAMPLE=xc7-litex
+  - TOOLCHAIN=xc7    OS=centos OS_VERSION=8       EXAMPLE=xc7-litex
+
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=xenial  EXAMPLE=xc7-linux
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=bionic  EXAMPLE=xc7-linux
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=eoan    EXAMPLE=xc7-linux
+  - TOOLCHAIN=xc7    OS=ubuntu OS_VERSION=focal   EXAMPLE=xc7-linux
+  - TOOLCHAIN=xc7    OS=centos OS_VERSION=7       EXAMPLE=xc7-linux
+  - TOOLCHAIN=xc7    OS=centos OS_VERSION=8       EXAMPLE=xc7-linux
 
 before_install:
  - sudo locale-gen "en_US.UTF-8"
@@ -51,5 +73,4 @@ install:
 
 script:
  # Run the tests inside the docker container.
- - if [ "$TOOLCHAIN" = "xc7" ]; then EXTRA_TESTS=,xc7-picosoc; fi
- - tuttest ${TOOLCHAIN}/README.rst ${TOOLCHAIN}-prepare-env,${TOOLCHAIN}-counter${EXTRA_TESTS} | ${IN_DOCKER_EXEC} "$(cat /dev/stdin)"
+ - tuttest ${TOOLCHAIN}/README.rst ${TOOLCHAIN}-prepare-env,${EXAMPLE} | ${IN_DOCKER_EXEC} "$(cat /dev/stdin)"

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ and so you will need to add some ``sudo`` commands to the instructions below.
         conda env create -f xc7/environment.yml
         conda activate xc7
         mkdir -p $INSTALL_DIR/xc7/install
-        wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/66/20200914-111752/symbiflow-arch-defs-install-05d68df0.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
+        wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/98/20201120-093358/symbiflow-arch-defs-install-d5f8ce8d.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
         conda deactivate
 
 * For the EOS S3 devices:

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,10 @@ and so you will need to add some ``sudo`` commands to the instructions below.
         conda env create -f xc7/environment.yml
         conda activate xc7
         mkdir -p $INSTALL_DIR/xc7/install
-        wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/98/20201120-093358/symbiflow-arch-defs-install-d5f8ce8d.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
+        wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/presubmit/install/1049/20201123-030526/symbiflow-arch-defs-install-05bd35c7.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
+        mkdir -p $INSTALL_DIR/xc7/install/share/symbiflow/arch
+        wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/presubmit/install/1049/20201123-030526/symbiflow-xc7a50t_test.tar.xz | tar -xJC $INSTALL_DIR/xc7/install/share/symbiflow/arch
+        wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/presubmit/install/1049/20201123-030526/symbiflow-xc7a100t_test.tar.xz | tar -xJC $INSTALL_DIR/xc7/install/share/symbiflow/arch
         conda deactivate
 
 * For the EOS S3 devices:

--- a/README.rst
+++ b/README.rst
@@ -163,7 +163,7 @@ To build the litex example, run the following commands:
         wget https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.1.0-2019.01.0-x86_64-linux-ubuntu14.tar.gz
         tar -xf riscv64-unknown-elf-gcc-8.1.0-2019.01.0-x86_64-linux-ubuntu14.tar.gz
         export PATH=$PATH:$PWD/riscv64-unknown-elf-gcc-8.1.0-2019.01.0-x86_64-linux-ubuntu14/bin/
-        pushd litex/litex/boards/targets && ./arty.py --toolchain symbiflow --cpu-type vexriscv --build && popd
+        pushd litex/litex/boards/targets && ./arty.py --toolchain symbiflow --cpu-type vexriscv --sys-clk-freq 80e6 --no-ident-version --build && popd
 
 To build the linux-litex-demo example, run the following commands:
 

--- a/xc7/README.rst
+++ b/xc7/README.rst
@@ -42,7 +42,10 @@ Choose the installation directory (see the `README <../README.rst>`_ one level u
         conda env create -f xc7/environment.yml
         conda activate xc7
         mkdir -p $INSTALL_DIR/xc7/install
-        wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/66/20200914-111752/symbiflow-arch-defs-install-05d68df0.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
+        wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/presubmit/install/1049/20201123-030526/symbiflow-arch-defs-install-05bd35c7.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
+        mkdir -p $INSTALL_DIR/xc7/install/share/symbiflow/arch
+        wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/presubmit/install/1049/20201123-030526/symbiflow-xc7a50t_test.tar.xz | tar -xJC $INSTALL_DIR/xc7/install/share/symbiflow/arch
+        wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/presubmit/install/1049/20201123-030526/symbiflow-xc7a100t_test.tar.xz | tar -xJC $INSTALL_DIR/xc7/install/share/symbiflow/arch
         conda deactivate
 
 .. toolchain_include_end_label
@@ -96,7 +99,7 @@ To build the litex example, run the following commands:
         wget https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.1.0-2019.01.0-x86_64-linux-ubuntu14.tar.gz
         tar -xf riscv64-unknown-elf-gcc-8.1.0-2019.01.0-x86_64-linux-ubuntu14.tar.gz
         export PATH=$PATH:$PWD/riscv64-unknown-elf-gcc-8.1.0-2019.01.0-x86_64-linux-ubuntu14/bin/
-        pushd litex/litex/boards/targets && ./arty.py --toolchain symbiflow --cpu-type vexriscv --build && popd
+        pushd litex/litex/boards/targets && ./arty.py --toolchain symbiflow --cpu-type vexriscv --sys-clk-freq 80e6 --no-ident-version --build && popd
 
 To build the linux-litex-demo example, run the following commands:
 

--- a/xc7/environment.yml
+++ b/xc7/environment.yml
@@ -3,9 +3,9 @@ channels:
   - symbiflow
 dependencies:
   - symbiflow::symbiflow-yosys=0.8_6021_gd8b2d1a2=20200708_083630
-  - symbiflow::symbiflow-yosys-plugins=1.0.0.7_0060_g7454cd6=20200902_114536
-  - symbiflow::symbiflow-vtr=8.0.0.rc2_4003_g8980e4621
-  - symbiflow::prjxray-db=0.0_0232_g303a61d=20200902_114536
+  - symbiflow::symbiflow-yosys-plugins=1.0.0.7_0174_g5e6370a=20201012_171341
+  - symbiflow::symbiflow-vtr=8.0.0.rc2_5097_gf1a3bcc2a=20200916_072439
+  - symbiflow::prjxray-db=0.0_0239_gd87c844=20201120_180018
   - symbiflow::prjxray-tools
   - make
   - lxml


### PR DESCRIPTION
This PR reenables litex tests. To fix the litex example we need to:
- update symbiflow toolchain packages
- split the examples into multiple jobs in Travis CI to match with the Travis build time limit

The changes from https://github.com/SymbiFlow/symbiflow-examples/pull/71 are included in this PR
Closes https://github.com/SymbiFlow/symbiflow-examples/pull/71