### PR TITLE
xc7: Use Conda packages from LiteX-Hub channel

### DIFF
--- a/xc7/environment.yml
+++ b/xc7/environment.yml
@@ -1,12 +1,12 @@
 name: xc7
 channels:
-  - symbiflow
+  - litex-hub
 dependencies:
-  - symbiflow::symbiflow-yosys=0.8_6021_gd8b2d1a2=20200708_083630
-  - symbiflow::symbiflow-yosys-plugins=1.0.0.7_0174_g5e6370a=20201012_171341
-  - symbiflow::symbiflow-vtr=8.0.0.rc2_5097_gf1a3bcc2a=20200916_072439
-  - symbiflow::prjxray-db=0.0_0239_gd87c844=20201120_180018
-  - symbiflow::prjxray-tools
+  - litex-hub::symbiflow-yosys=0.8_6021_gd8b2d1a2=20201120_145821_libffi33
+  - litex-hub::symbiflow-yosys-plugins=1.0.0.7_0174_g5e6370a=20201012_171341
+  - litex-hub::symbiflow-vtr=8.0.0rc2_5082_gf1a3bcc2a=20201105_110531
+  - litex-hub::prjxray-db=0.0_0239_gd87c844=20201120_145821
+  - litex-hub::prjxray-tools=0.1_2697_g0f939808=20201120_145821
   - make
   - lxml
   - simplejson


### PR DESCRIPTION
These are the same versions of packages that have been successfully
tested in a PR for `symbiflow-arch-defs`: https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1795

The `symbiflow-arch-defs` URL will be updated when the PR gets merged.