### PR TITLE
xc7: Separate build directory for each board

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,9 +144,9 @@ To build the counter example, run any or all of the following commands:
 .. code:: bash
         :name: xc7-counter
 
-        pushd xc7/counter_test && make clean && TARGET="arty_35" make && popd
-        pushd xc7/counter_test && make clean && TARGET="arty_100" make && popd
-        pushd xc7/counter_test && make clean && TARGET="basys3" make && popd
+        pushd xc7/counter_test && TARGET="arty_35" make && popd
+        pushd xc7/counter_test && TARGET="arty_100" make && popd
+        pushd xc7/counter_test && TARGET="basys3" make && popd
 
 To build the picosoc example, run the following commands:
 

--- a/xc7/README.rst
+++ b/xc7/README.rst
@@ -76,9 +76,9 @@ To build the counter example, run any or all of the following commands:
 .. code:: bash
         :name: xc7-counter
 
-        pushd xc7/counter_test && make clean && TARGET="arty_35" make && popd
-        pushd xc7/counter_test && make clean && TARGET="arty_100" make && popd
-        pushd xc7/counter_test && make clean && TARGET="basys3" make && popd
+        pushd xc7/counter_test && TARGET="arty_35" make && popd
+        pushd xc7/counter_test && TARGET="arty_100" make && popd
+        pushd xc7/counter_test && TARGET="basys3" make && popd
 
 To build the picosoc example, run the following commands:
 

--- a/xc7/counter_test/Makefile
+++ b/xc7/counter_test/Makefile
@@ -10,38 +10,40 @@ BUILDDIR:=build
 ifeq ($(TARGET),arty_35)
   PARTNAME := xc7a35tcsg324-1
   PCF:=${current_dir}/arty.pcf
+  BOARD_BUILDDIR := ${BUILDDIR}/arty_35
 else ifeq ($(TARGET),arty_100)
   PARTNAME:= xc7a100tcsg324-1
   PCF:=${current_dir}/arty.pcf
   DEVICE:= xc7a100t_test
+  BOARD_BUILDDIR := ${BUILDDIR}/arty_100
 else
   PARTNAME:= xc7a35tcpg236-1
   PCF:=${current_dir}/basys3.pcf
+  BOARD_BUILDDIR := ${BUILDDIR}/basys3
 endif
 
-all: ${BUILDDIR}/${TOP}.bit
+all: ${BOARD_BUILDDIR}/${TOP}.bit
 
-${BUILDDIR}:
-	mkdir ${BUILDDIR}
+${BOARD_BUILDDIR}:
+	mkdir -p ${BOARD_BUILDDIR}
 
-${BUILDDIR}/${TOP}.eblif: | ${BUILDDIR}
-	cd ${BUILDDIR} && symbiflow_synth -t ${TOP} -v ${VERILOG} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} 2>&1 > /dev/null
+${BOARD_BUILDDIR}/${TOP}.eblif: | ${BOARD_BUILDDIR}
+	cd ${BOARD_BUILDDIR} && symbiflow_synth -t ${TOP} -v ${VERILOG} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} 2>&1 > /dev/null
 
-${BUILDDIR}/${TOP}.net: ${BUILDDIR}/${TOP}.eblif
-	cd ${BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
+${BOARD_BUILDDIR}/${TOP}.net: ${BOARD_BUILDDIR}/${TOP}.eblif
+	cd ${BOARD_BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
 
-${BUILDDIR}/${TOP}.place: ${BUILDDIR}/${TOP}.net
-	cd ${BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -p ${PCF} -n ${TOP}.net -P ${PARTNAME} -s ${SDC} 2>&1 > /dev/null
+${BOARD_BUILDDIR}/${TOP}.place: ${BOARD_BUILDDIR}/${TOP}.net
+	cd ${BOARD_BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -p ${PCF} -n ${TOP}.net -P ${PARTNAME} -s ${SDC} 2>&1 > /dev/null
 
-${BUILDDIR}/${TOP}.route: ${BUILDDIR}/${TOP}.place
-	cd ${BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
+${BOARD_BUILDDIR}/${TOP}.route: ${BOARD_BUILDDIR}/${TOP}.place
+	cd ${BOARD_BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
 
-${BUILDDIR}/${TOP}.fasm: ${BUILDDIR}/${TOP}.route
-	cd ${BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE}
+${BOARD_BUILDDIR}/${TOP}.fasm: ${BOARD_BUILDDIR}/${TOP}.route
+	cd ${BOARD_BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE}
 
-${BUILDDIR}/${TOP}.bit: ${BUILDDIR}/${TOP}.fasm
-	cd ${BUILDDIR} && symbiflow_write_bitstream -d ${BITSTREAM_DEVICE} -f ${TOP}.fasm -p ${PARTNAME} -b ${TOP}.bit
+${BOARD_BUILDDIR}/${TOP}.bit: ${BOARD_BUILDDIR}/${TOP}.fasm
+	cd ${BOARD_BUILDDIR} && symbiflow_write_bitstream -d ${BITSTREAM_DEVICE} -f ${TOP}.fasm -p ${PARTNAME} -b ${TOP}.bit
 
 clean:
 	rm -rf ${BUILDDIR}
-

--- a/xc7/linux_litex_demo/Makefile
+++ b/xc7/linux_litex_demo/Makefile
@@ -10,42 +10,41 @@ BITSTREAM_DEVICE := artix7
 PCF := ${current_dir}/arty.pcf
 SDC := ${current_dir}/arty.sdc
 XDC := ${current_dir}/arty.xdc
-BUILDDIR_35  := build
-BUILDDIR_100 := build_100
+BUILDDIR := build
 
 ifeq ($(TARGET),arty_100)
     PARTNAME := xc7a100tcsg324-1
     DEVICE   := xc7a100t_test
-    BUILDDIR := ${BUILDDIR_100}
+    BOARD_BUILDDIR := ${BUILDDIR}/arty_35
 else
     PARTNAME := xc7a35tcsg324-1
     DEVICE   := xc7a50t_test
-    BUILDDIR := ${BUILDDIR_35}
+    BOARD_BUILDDIR := ${BUILDDIR}/arty_100
 endif
 
-all: ${BUILDDIR}/${TOP}.bit
+all: ${BOARD_BUILDDIR}/${TOP}.bit
 
-${BUILDDIR}:
-	mkdir ${BUILDDIR}
-	ln -s ${MEM_INIT} ${BUILDDIR}
+${BOARD_BUILDDIR}:
+	mkdir -p ${BOARD_BUILDDIR}
+	ln -s ${MEM_INIT} ${BOARD_BUILDDIR}
 
-${BUILDDIR}/${TOP}.eblif: | ${BUILDDIR}
-	cd ${BUILDDIR} && symbiflow_synth -t ${TOP} -v ${VERILOG} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} -x ${XDC} 2>&1 > /dev/null
+${BOARD_BUILDDIR}/${TOP}.eblif: | ${BOARD_BUILDDIR}
+	cd ${BOARD_BUILDDIR} && symbiflow_synth -t ${TOP} -v ${VERILOG} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} -x ${XDC} 2>&1 > /dev/null
 
-${BUILDDIR}/${TOP}.net: ${BUILDDIR}/${TOP}.eblif
-	cd ${BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
+${BOARD_BUILDDIR}/${TOP}.net: ${BOARD_BUILDDIR}/${TOP}.eblif
+	cd ${BOARD_BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
 
-${BUILDDIR}/${TOP}.place: ${BUILDDIR}/${TOP}.net
-	cd ${BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -p ${PCF} -n ${TOP}.net -P ${PARTNAME} -s ${SDC} 2>&1 > /dev/null
+${BOARD_BUILDDIR}/${TOP}.place: ${BOARD_BUILDDIR}/${TOP}.net
+	cd ${BOARD_BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -p ${PCF} -n ${TOP}.net -P ${PARTNAME} -s ${SDC} 2>&1 > /dev/null
 
-${BUILDDIR}/${TOP}.route: ${BUILDDIR}/${TOP}.place
-	cd ${BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
+${BOARD_BUILDDIR}/${TOP}.route: ${BOARD_BUILDDIR}/${TOP}.place
+	cd ${BOARD_BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
 
-${BUILDDIR}/${TOP}.fasm: ${BUILDDIR}/${TOP}.route
-	cd ${BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE}
+${BOARD_BUILDDIR}/${TOP}.fasm: ${BOARD_BUILDDIR}/${TOP}.route
+	cd ${BOARD_BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE}
 
-${BUILDDIR}/${TOP}.bit: ${BUILDDIR}/${TOP}.fasm
-	cd ${BUILDDIR} && symbiflow_write_bitstream -d ${BITSTREAM_DEVICE} -f ${TOP}.fasm -p ${PARTNAME} -b ${TOP}.bit
+${BOARD_BUILDDIR}/${TOP}.bit: ${BOARD_BUILDDIR}/${TOP}.fasm
+	cd ${BOARD_BUILDDIR} && symbiflow_write_bitstream -d ${BITSTREAM_DEVICE} -f ${TOP}.fasm -p ${PARTNAME} -b ${TOP}.bit
 
 clean:
-	rm -rf ${BUILDDIR_35} ${BUILDDIR_100}
+	rm -rf ${BUILDDIR}


### PR DESCRIPTION
This PR separates the build directory for every board. 
This gives an opportunity to have bitstreams for various boards in the CI artifacts.