### PR TITLE
xc7: fix python requirements

### DIFF
--- a/xc7/requirements.txt
+++ b/xc7/requirements.txt
@@ -1,3 +1,4 @@
 python-constraint
 git+https://github.com/symbiflow/fasm
+git+git://github.com/SymbiFlow/prjxray.git#egg=prjxray
 git+https://github.com/symbiflow/xc-fasm


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR fixes the conda build during pip packages installation. Basically, the xc-fasm package was previously installing dependencies such as prjxray, which now should be installed in here, rather then allowing pip to install them automatically.

This is related to recent changes to the xc-fasm repo: SymbiFlow/xc-fasm#7