### PR TITLE
ci: drop non-LTS eoan from CI tests

### DIFF
--- a/.github/workflows/tuttest.yml
+++ b/.github/workflows/tuttest.yml
@@ -10,35 +10,30 @@ jobs:
         include:
           - {toolchain: "eos-s3", os: "ubuntu", os-version: "xenial", example: "eos-s3-counter"}
           - {toolchain: "eos-s3", os: "ubuntu", os-version: "bionic", example: "eos-s3-counter"}
-          - {toolchain: "eos-s3", os: "ubuntu", os-version: "eoan",   example: "eos-s3-counter"}
           - {toolchain: "eos-s3", os: "ubuntu", os-version: "focal",  example: "eos-s3-counter"}
           - {toolchain: "eos-s3", os: "centos", os-version: "7",      example: "eos-s3-counter"}
           - {toolchain: "eos-s3", os: "centos", os-version: "8",      example: "eos-s3-counter"}
 
           - {toolchain: "xc7",    os: "ubuntu", os-version: "xenial", example: "xc7-counter"}
           - {toolchain: "xc7",    os: "ubuntu", os-version: "bionic", example: "xc7-counter"}
-          - {toolchain: "xc7",    os: "ubuntu", os-version: "eoan",   example: "xc7-counter"}
           - {toolchain: "xc7",    os: "ubuntu", os-version: "focal",  example: "xc7-counter"}
           - {toolchain: "xc7",    os: "centos", os-version: "7",      example: "xc7-counter"}
           - {toolchain: "xc7",    os: "centos", os-version: "8",      example: "xc7-counter"}
 
           - {toolchain: "xc7",    os: "ubuntu", os-version: "xenial", example: "xc7-picosoc"}
           - {toolchain: "xc7",    os: "ubuntu", os-version: "bionic", example: "xc7-picosoc"}
-          - {toolchain: "xc7",    os: "ubuntu", os-version: "eoan",   example: "xc7-picosoc"}
           - {toolchain: "xc7",    os: "ubuntu", os-version: "focal",  example: "xc7-picosoc"}
           - {toolchain: "xc7",    os: "centos", os-version: "7",      example: "xc7-picosoc"}
           - {toolchain: "xc7",    os: "centos", os-version: "8",      example: "xc7-picosoc"}
 
           - {toolchain: "xc7",    os: "ubuntu", os-version: "xenial", example: "xc7-litex"}
           - {toolchain: "xc7",    os: "ubuntu", os-version: "bionic", example: "xc7-litex"}
-          - {toolchain: "xc7",    os: "ubuntu", os-version: "eoan",   example: "xc7-litex"}
           - {toolchain: "xc7",    os: "ubuntu", os-version: "focal",  example: "xc7-litex"}
           - {toolchain: "xc7",    os: "centos", os-version: "7",      example: "xc7-litex"}
           - {toolchain: "xc7",    os: "centos", os-version: "8",      example: "xc7-litex"}
 
           - {toolchain: "xc7",    os: "ubuntu", os-version: "xenial", example: "xc7-linux"}
           - {toolchain: "xc7",    os: "ubuntu", os-version: "bionic", example: "xc7-linux"}
-          - {toolchain: "xc7",    os: "ubuntu", os-version: "eoan",   example: "xc7-linux"}
           - {toolchain: "xc7",    os: "ubuntu", os-version: "focal",  example: "xc7-linux"}
           - {toolchain: "xc7",    os: "centos", os-version: "7",      example: "xc7-linux"}
           - {toolchain: "xc7",    os: "centos", os-version: "8",      example: "xc7-linux"}


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

The eoan Ubuntu version (19.10) is causing failures on CI. Unsure whether there is  a temporary maintenance to the packages, but in general, it is worth to keep tested only the LTS OSes versions.

Example of failing build: https://github.com/SymbiFlow/symbiflow-examples/runs/1531376091?check_suite_focus=true