### PR TITLE
Add debian bullseye and debian sid to CI tests

### DIFF
--- a/.github/workflows/sphinx-tuttest.yml
+++ b/.github/workflows/sphinx-tuttest.yml
@@ -9,33 +9,41 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {fpga-fam: "eos-s3", os: "ubuntu", os-version: "xenial", example: "counter"}
-          - {fpga-fam: "eos-s3", os: "ubuntu", os-version: "bionic", example: "counter"}
-          - {fpga-fam: "eos-s3", os: "ubuntu", os-version: "focal",  example: "counter"}
-          - {fpga-fam: "eos-s3", os: "centos", os-version: "7",      example: "counter"}
-          - {fpga-fam: "eos-s3", os: "centos", os-version: "8",      example: "counter"}
-          - {fpga-fam: "eos-s3", os: "debian", os-version: "buster", example: "counter"}
+          - {fpga-fam: "eos-s3", os: "ubuntu", os-version: "xenial",   example: "counter"}
+          - {fpga-fam: "eos-s3", os: "ubuntu", os-version: "bionic",   example: "counter"}
+          - {fpga-fam: "eos-s3", os: "ubuntu", os-version: "focal",    example: "counter"}
+          - {fpga-fam: "eos-s3", os: "centos", os-version: "7",        example: "counter"}
+          - {fpga-fam: "eos-s3", os: "centos", os-version: "8",        example: "counter"}
+          - {fpga-fam: "eos-s3", os: "debian", os-version: "buster",   example: "counter"}
+          - {fpga-fam: "eos-s3", os: "debian", os-version: "bullseye", example: "counter"}
+          - {fpga-fam: "eos-s3", os: "debian", os-version: "sid",      example: "counter"}
 
-          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "xenial", example: "counter"}
-          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "bionic", example: "counter"}
-          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "focal",  example: "counter"}
-          - {fpga-fam: "xc7",    os: "centos", os-version: "7",      example: "counter"}
-          - {fpga-fam: "xc7",    os: "centos", os-version: "8",      example: "counter"}
-          - {fpga-fam: "xc7",    os: "debian", os-version: "buster", example: "counter"}
+          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "xenial",   example: "counter"}
+          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "bionic",   example: "counter"}
+          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "focal",    example: "counter"}
+          - {fpga-fam: "xc7",    os: "centos", os-version: "7",        example: "counter"}
+          - {fpga-fam: "xc7",    os: "centos", os-version: "8",        example: "counter"}
+          - {fpga-fam: "xc7",    os: "debian", os-version: "buster",   example: "counter"}
+          - {fpga-fam: "xc7",    os: "debian", os-version: "bullseye", example: "counter"}
+          - {fpga-fam: "xc7",    os: "debian", os-version: "sid",      example: "counter"}
 
-          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "xenial", example: "picosoc"}
-          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "bionic", example: "picosoc"}
-          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "focal",  example: "picosoc"}
-          - {fpga-fam: "xc7",    os: "centos", os-version: "7",      example: "picosoc"}
-          - {fpga-fam: "xc7",    os: "centos", os-version: "8",      example: "picosoc"}
-          - {fpga-fam: "xc7",    os: "debian", os-version: "buster", example: "picosoc"}
+          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "xenial",   example: "picosoc"}
+          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "bionic",   example: "picosoc"}
+          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "focal",    example: "picosoc"}
+          - {fpga-fam: "xc7",    os: "centos", os-version: "7",        example: "picosoc"}
+          - {fpga-fam: "xc7",    os: "centos", os-version: "8",        example: "picosoc"}
+          - {fpga-fam: "xc7",    os: "debian", os-version: "buster",   example: "picosoc"}
+          - {fpga-fam: "xc7",    os: "debian", os-version: "bullseye", example: "picosoc"}
+          - {fpga-fam: "xc7",    os: "debian", os-version: "sid",      example: "picosoc"}
 
-          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "xenial", example: "litex_linux"}
-          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "bionic", example: "litex_linux"}
-          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "focal",  example: "litex_linux"}
-          - {fpga-fam: "xc7",    os: "centos", os-version: "7",      example: "litex_linux"}
-          - {fpga-fam: "xc7",    os: "centos", os-version: "8",      example: "litex_linux"}
-          - {fpga-fam: "xc7",    os: "debian", os-version: "buster", example: "litex_linux"}
+          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "xenial",   example: "litex_linux"}
+          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "bionic",   example: "litex_linux"}
+          - {fpga-fam: "xc7",    os: "ubuntu", os-version: "focal",    example: "litex_linux"}
+          - {fpga-fam: "xc7",    os: "centos", os-version: "7",        example: "litex_linux"}
+          - {fpga-fam: "xc7",    os: "centos", os-version: "8",        example: "litex_linux"}
+          - {fpga-fam: "xc7",    os: "debian", os-version: "buster",   example: "litex_linux"}
+          - {fpga-fam: "xc7",    os: "debian", os-version: "bullseye", example: "litex_linux"}
+          - {fpga-fam: "xc7",    os: "debian", os-version: "sid",      example: "litex_linux"}
     env:
       LANG: "en_US.UTF-8"
       DOCKER_NAME: test


### PR DESCRIPTION
According to the @mithro's suggestion in https://github.com/SymbiFlow/symbiflow-examples/pull/99, this PR adds `debian testing (bullseye)` and `debian unstable (sid)` to the CI tests.