### PR TITLE
xc7: fix linux_litex_demo build paths

### DIFF
--- a/xc7/linux_litex_demo/Makefile
+++ b/xc7/linux_litex_demo/Makefile
@@ -15,11 +15,11 @@ BUILDDIR := build
 ifeq ($(TARGET),arty_100)
     PARTNAME := xc7a100tcsg324-1
     DEVICE   := xc7a100t_test
-    BOARD_BUILDDIR := ${BUILDDIR}/arty_35
+    BOARD_BUILDDIR := ${BUILDDIR}/arty_100
 else
     PARTNAME := xc7a35tcsg324-1
     DEVICE   := xc7a50t_test
-    BOARD_BUILDDIR := ${BUILDDIR}/arty_100
+    BOARD_BUILDDIR := ${BUILDDIR}/arty_35
 endif
 
 all: ${BOARD_BUILDDIR}/${TOP}.bit


### PR DESCRIPTION
The destination directory names for arty 35 and 100 were swapped in
refactoring.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>