### PR TITLE
Add .DELETE_ON_ERROR to Makefiles (issue #119).

### DIFF
--- a/xc7/counter_test/Makefile
+++ b/xc7/counter_test/Makefile
@@ -33,6 +33,9 @@ else
   BOARD_BUILDDIR := ${BUILDDIR}/basys3
 endif
 
+.DELETE_ON_ERROR:
+
+
 all: ${BOARD_BUILDDIR}/${TOP}.bit
 
 ${BOARD_BUILDDIR}:

--- a/xc7/linux_litex_demo/Makefile
+++ b/xc7/linux_litex_demo/Makefile
@@ -22,6 +22,9 @@ else
     BOARD_BUILDDIR := ${BUILDDIR}/arty_35
 endif
 
+.DELETE_ON_ERROR:
+
+
 all: ${BOARD_BUILDDIR}/${TOP}.bit
 
 ${BOARD_BUILDDIR}:

--- a/xc7/picosoc_demo/Makefile
+++ b/xc7/picosoc_demo/Makefile
@@ -30,6 +30,9 @@ else
   BOARD_BUILDDIR := ${BUILDDIR}/basys3
 endif
 
+.DELETE_ON_ERROR:
+
+
 all: ${BUILDDIR}/${TOP}.bit
 
 ${BUILDDIR}:


### PR DESCRIPTION
Signed-off-by: Tim Callahan <tcal@google.com>