### PR TITLE
Force fixed tbb package version in eos-s3 env

### DIFF
--- a/eos-s3/environment.yml
+++ b/eos-s3/environment.yml
@@ -6,6 +6,8 @@ dependencies:
   - litex-hub::quicklogic-yosys=0.8.0_0021_g5eaf370c=20201120_145821
   - litex-hub::quicklogic-yosys-plugins=1.2.0_0009_g9ab211c=20201120_145821
   - litex-hub::quicklogic-vtr=v8.0.0.rc2_4003_g8980e4621=20200902_114536
+  # FIXME: remove tbb pin once https://github.com/hdl/conda-eda/issues/84 is fixed
+  - tbb=2020.2
   - make
   - lxml
   - simplejson

--- a/eos-s3/requirements.txt
+++ b/eos-s3/requirements.txt
@@ -1,2 +1,2 @@
 python-constraint
-git+https://github.com/QuickLogic-Corp/quicklogic-fasm
+git+https://github.com/QuickLogic-Corp/quicklogic-fasm@2312ff03d5690449a597e565430764a162d452b7


### PR DESCRIPTION
This PR forces older (2020.2) version o the package. Never ones do not provide `libtbb.so.2` (required by VPR version we currently use)