### PR TITLE
xc7: pin xc-fasm version

### DIFF
--- a/xc7/requirements.txt
+++ b/xc7/requirements.txt
@@ -16,4 +16,4 @@ yapf==0.24.0
 python-constraint
 git+https://github.com/symbiflow/fasm
 git+https://github.com/SymbiFlow/prjxray.git@905a6b5b0407b45b6b7484741c8f701dcfa6b81d#egg=prjxray
-git+https://github.com/symbiflow/xc-fasm
+git+https://github.com/symbiflow/xc-fasm.git@e12f31334e96fedf3af86d13cf51f70ad2270f5f#egg=xc-fasm

--- a/xc7/requirements.txt
+++ b/xc7/requirements.txt
@@ -14,6 +14,6 @@ sympy
 textx
 yapf==0.24.0
 python-constraint
-git+https://github.com/symbiflow/fasm
+fasm
 git+https://github.com/SymbiFlow/prjxray.git@905a6b5b0407b45b6b7484741c8f701dcfa6b81d#egg=prjxray
 git+https://github.com/symbiflow/xc-fasm.git@e12f31334e96fedf3af86d13cf51f70ad2270f5f#egg=xc-fasm


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR pins the xc-fasm version as new-packages need to be generated after https://github.com/SymbiFlow/xc-fasm/pull/11