### PR TITLE
Remove `file:` from top level conda env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - pip
   - litex-hub::verible
   - pip:
-    - -r file:requirements.txt
+    - -r requirements.txt


### PR DESCRIPTION
Signed-off-by: Karol Gugala <kgugala@antmicro.com>