### PR TITLE
Common Makefile

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -1,0 +1,86 @@
+BUILDDIR := ${current_dir}/build
+
+# Set board properties based on TARGET variable
+ifeq ($(TARGET),arty_35)
+  DEVICE := xc7a50t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a35tcsg324-1
+  CONSTRAINT_PATH := ${current_dir}/arty
+  BOARD_BUILDDIR := ${BUILDDIR}/arty_35
+else ifeq ($(TARGET),arty_100)
+  DEVICE := xc7a100t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a100tcsg324-1
+  CONSTRAINT_PATH := ${current_dir}/arty
+  BOARD_BUILDDIR := ${BUILDDIR}/arty_100
+else ifeq ($(TARGET),nexys4ddr)
+  DEVICE := xc7a100t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a100tcsg324-1
+  CONSTRAINT_PATH := ${current_dir}/nexys4ddr
+  BOARD_BUILDDIR := ${BUILDDIR}/nexys4ddr
+else ifeq ($(TARGET),zybo)
+  DEVICE := xc7z010_test
+  BITSTREAM_DEVICE := zynq7
+  PARTNAME := xc7z010clg400-1
+  CONSTRAINT_PATH := ${current_dir}/zybo
+  BOARD_BUILDDIR := ${BUILDDIR}/zybo
+  SOURCES := ${current_dir}/counter_zynq.v
+else ifeq ($(TARGET),nexys_video)
+  DEVICE := xc7a200t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a200tsbg484-1
+  CONSTRAINT_PATH := ${current_dir}/nexys_video
+  BOARD_BUILDDIR := ${BUILDDIR}/nexys_video
+else
+  DEVICE := xc7a50t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a35tcpg236-1
+  CONSTRAINT_PATH := ${current_dir}/basys3
+  BOARD_BUILDDIR := ${BUILDDIR}/basys3
+endif
+
+# Determine the type of constraint being used
+ifneq ($(wildcard ${CONSTRAINT_PATH}.xdc),)
+  XDC_CMD := -x ${CONSTRAINT_PATH}.xdc
+endif
+ifneq ($(wildcard ${CONSTRAINT_PATH}.sdc),)
+  SDC_CMD := -s ${CONSTRAINT_PATH}.sdc
+endif
+ifneq ($(wildcard ${CONSTRAINT_PATH}.pcf),)
+  PCF_CMD := -p ${CONSTRAINT_PATH}.pcf
+endif
+
+.DELETE_ON_ERROR:
+
+# Build design
+all: ${BOARD_BUILDDIR}/${TOP}.bit
+
+${BOARD_BUILDDIR}:
+	mkdir -p ${BOARD_BUILDDIR}
+  #Check if design includes initialization files for memory
+  ifneq (${MEM_INIT},)
+    #if there are memory initialization files link them to the build/board_type directory
+	  ln -s ${MEM_INIT} ${BOARD_BUILDDIR}
+  endif
+
+${BOARD_BUILDDIR}/${TOP}.eblif: | ${BOARD_BUILDDIR}
+	cd ${BOARD_BUILDDIR} && symbiflow_synth -t ${TOP} -v ${SOURCES} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} ${XDC_CMD} 2>&1 > /dev/null
+
+${BOARD_BUILDDIR}/${TOP}.net: ${BOARD_BUILDDIR}/${TOP}.eblif
+	cd ${BOARD_BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} ${SDC_CMD} 2>&1 > /dev/null
+
+${BOARD_BUILDDIR}/${TOP}.place: ${BOARD_BUILDDIR}/${TOP}.net
+	cd ${BOARD_BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} ${PCF_CMD} -n ${TOP}.net -P ${PARTNAME} ${SDC_CMD} 2>&1 > /dev/null
+
+${BOARD_BUILDDIR}/${TOP}.route: ${BOARD_BUILDDIR}/${TOP}.place
+	cd ${BOARD_BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} ${SDC_CMD} 2>&1 > /dev/null
+
+${BOARD_BUILDDIR}/${TOP}.fasm: ${BOARD_BUILDDIR}/${TOP}.route
+	cd ${BOARD_BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE}
+
+${BOARD_BUILDDIR}/${TOP}.bit: ${BOARD_BUILDDIR}/${TOP}.fasm
+	cd ${BOARD_BUILDDIR} && symbiflow_write_bitstream -d ${BITSTREAM_DEVICE} -f ${TOP}.fasm -p ${PARTNAME} -b ${TOP}.bit
+
+clean:
+	rm -rf ${BUILDDIR}

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,54 +1,15 @@
 BUILDDIR := ${current_dir}/build
-
-# Set board properties based on TARGET variable
-ifeq ($(TARGET),arty_35)
-  DEVICE := xc7a50t_test
-  BITSTREAM_DEVICE := artix7
-  PARTNAME := xc7a35tcsg324-1
-  CONSTRAINT_PATH := ${current_dir}/arty
-  BOARD_BUILDDIR := ${BUILDDIR}/arty_35
-else ifeq ($(TARGET),arty_100)
-  DEVICE := xc7a100t_test
-  BITSTREAM_DEVICE := artix7
-  PARTNAME := xc7a100tcsg324-1
-  CONSTRAINT_PATH := ${current_dir}/arty
-  BOARD_BUILDDIR := ${BUILDDIR}/arty_100
-else ifeq ($(TARGET),nexys4ddr)
-  DEVICE := xc7a100t_test
-  BITSTREAM_DEVICE := artix7
-  PARTNAME := xc7a100tcsg324-1
-  CONSTRAINT_PATH := ${current_dir}/nexys4ddr
-  BOARD_BUILDDIR := ${BUILDDIR}/nexys4ddr
-else ifeq ($(TARGET),zybo)
-  DEVICE := xc7z010_test
-  BITSTREAM_DEVICE := zynq7
-  PARTNAME := xc7z010clg400-1
-  CONSTRAINT_PATH := ${current_dir}/zybo
-  BOARD_BUILDDIR := ${BUILDDIR}/zybo
-  SOURCES := ${current_dir}/counter_zynq.v
-else ifeq ($(TARGET),nexys_video)
-  DEVICE := xc7a200t_test
-  BITSTREAM_DEVICE := artix7
-  PARTNAME := xc7a200tsbg484-1
-  CONSTRAINT_PATH := ${current_dir}/nexys_video
-  BOARD_BUILDDIR := ${BUILDDIR}/nexys_video
-else
-  DEVICE := xc7a50t_test
-  BITSTREAM_DEVICE := artix7
-  PARTNAME := xc7a35tcpg236-1
-  CONSTRAINT_PATH := ${current_dir}/basys3
-  BOARD_BUILDDIR := ${BUILDDIR}/basys3
-endif
+BOARD_BUILDDIR := ${BUILDDIR}/${TARGET}
 
 # Determine the type of constraint being used
-ifneq ($(wildcard ${CONSTRAINT_PATH}.xdc),)
-  XDC_CMD := -x ${CONSTRAINT_PATH}.xdc
+ifneq (${XDC},)
+  XDC_CMD := -x ${XDC}
 endif
-ifneq ($(wildcard ${CONSTRAINT_PATH}.sdc),)
-  SDC_CMD := -s ${CONSTRAINT_PATH}.sdc
+ifneq (${SDC},)
+  SDC_CMD := -s ${SDC}
 endif
-ifneq ($(wildcard ${CONSTRAINT_PATH}.pcf),)
-  PCF_CMD := -p ${CONSTRAINT_PATH}.pcf
+ifneq (${PCF},)
+  PCF_CMD := -p ${PCF}
 endif
 
 .DELETE_ON_ERROR:

--- a/common/Makefile
+++ b/common/Makefile
@@ -48,11 +48,6 @@ all: ${BOARD_BUILDDIR}/${TOP}.bit
 
 ${BOARD_BUILDDIR}:
 	mkdir -p ${BOARD_BUILDDIR}
-  #Check if design includes initialization files for memory
-  ifneq (${MEM_INIT},)
-    #if there are memory initialization files link them to the build/board_type directory
-	  ln -s ${MEM_INIT} ${BOARD_BUILDDIR}
-  endif
 
 ${BOARD_BUILDDIR}/${TOP}.eblif: | ${BOARD_BUILDDIR}
 	cd ${BOARD_BUILDDIR} && symbiflow_synth -t ${TOP} -v ${SOURCES} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} ${XDC_CMD} 2>&1 > /dev/null

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,6 +1,35 @@
 BUILDDIR := ${current_dir}/build
 BOARD_BUILDDIR := ${BUILDDIR}/${TARGET}
 
+# Set board properties based on TARGET variable
+ifeq ($(TARGET),arty_35)
+  DEVICE := xc7a50t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a35tcsg324-1
+else ifeq ($(TARGET),arty_100)
+  DEVICE := xc7a100t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a100tcsg324-1
+else ifeq ($(TARGET),nexys4ddr)
+  DEVICE := xc7a100t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a100tcsg324-1
+else ifeq ($(TARGET),zybo)
+  DEVICE := xc7z010_test
+  BITSTREAM_DEVICE := zynq7
+  PARTNAME := xc7z010clg400-1
+else ifeq ($(TARGET),nexys_video)
+  DEVICE := xc7a200t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a200tsbg484-1
+else ifeq ($(TARGET),basys3)
+  DEVICE := xc7a50t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a35tcpg236-1
+else
+  $(error Unsupported board type)
+endif
+
 # Determine the type of constraint being used
 ifneq (${XDC},)
   XDC_CMD := -x ${XDC}

--- a/xc7/counter_test/Makefile
+++ b/xc7/counter_test/Makefile
@@ -17,10 +17,5 @@ else
   XDC := ${current_dir}/basys3.xdc
 endif
 
-export
-
-all:
-	cd ../../common && $(MAKE)
-clean:
-	cd ../../common && $(MAKE) clean    
+include ${current_dir}/../../common/Makefile
 

--- a/xc7/counter_test/Makefile
+++ b/xc7/counter_test/Makefile
@@ -1,68 +1,12 @@
-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
-TOP := top
-VERILOG := ${current_dir}/counter.v
-DEVICE := xc7a50t_test
-BITSTREAM_DEVICE := artix7
-BUILDDIR := build
+export mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+export current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 
-ifeq ($(TARGET),arty_35)
-  PARTNAME := xc7a35tcsg324-1
-  XDC := ${current_dir}/arty.xdc
-  BOARD_BUILDDIR := ${BUILDDIR}/arty_35
-else ifeq ($(TARGET),arty_100)
-  PARTNAME := xc7a100tcsg324-1
-  XDC := ${current_dir}/arty.xdc
-  DEVICE := xc7a100t_test
-  BOARD_BUILDDIR := ${BUILDDIR}/arty_100
-else ifeq ($(TARGET),nexys4ddr)
-  PARTNAME := xc7a100tcsg324-1
-  XDC := ${current_dir}/nexys4ddr.xdc
-  DEVICE := xc7a100t_test
-  BOARD_BUILDDIR := ${BUILDDIR}/nexys4ddr
-else ifeq ($(TARGET),zybo)
-  PARTNAME := xc7z010clg400-1
-  XDC := ${current_dir}/zybo.xdc
-  DEVICE := xc7z010_test
-  BITSTREAM_DEVICE := zynq7
-  BOARD_BUILDDIR := ${BUILDDIR}/zybo
-  VERILOG:=${current_dir}/counter_zynq.v
-else ifeq ($(TARGET),nexys_video)
-  PARTNAME := xc7a200tsbg484-1
-  XDC := ${current_dir}/nexys_video.xdc
-  DEVICE := xc7a200t_test
-  BOARD_BUILDDIR := ${BUILDDIR}/nexys_video
-else
-  PARTNAME := xc7a35tcpg236-1
-  XDC := ${current_dir}/basys3.xdc
-  BOARD_BUILDDIR := ${BUILDDIR}/basys3
-endif
+export TOP := top
+export SOURCES := ${current_dir}/counter.v
 
-.DELETE_ON_ERROR:
-
-
-all: ${BOARD_BUILDDIR}/${TOP}.bit
-
-${BOARD_BUILDDIR}:
-	mkdir -p ${BOARD_BUILDDIR}
-
-${BOARD_BUILDDIR}/${TOP}.eblif: | ${BOARD_BUILDDIR}
-	cd ${BOARD_BUILDDIR} && symbiflow_synth -t ${TOP} -v ${VERILOG} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} -x ${XDC} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.net: ${BOARD_BUILDDIR}/${TOP}.eblif
-	cd ${BOARD_BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.place: ${BOARD_BUILDDIR}/${TOP}.net
-	cd ${BOARD_BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -n ${TOP}.net -P ${PARTNAME} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.route: ${BOARD_BUILDDIR}/${TOP}.place
-	cd ${BOARD_BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.fasm: ${BOARD_BUILDDIR}/${TOP}.route
-	cd ${BOARD_BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE}
-
-${BOARD_BUILDDIR}/${TOP}.bit: ${BOARD_BUILDDIR}/${TOP}.fasm
-	cd ${BOARD_BUILDDIR} && symbiflow_write_bitstream -d ${BITSTREAM_DEVICE} -f ${TOP}.fasm -p ${PARTNAME} -b ${TOP}.bit
+all:
+	cd ../../common && $(MAKE)
 
 clean:
-	rm -rf ${BUILDDIR}
+	cd ../../common && $(MAKE) clean    
+

--- a/xc7/counter_test/Makefile
+++ b/xc7/counter_test/Makefile
@@ -1,12 +1,44 @@
-export mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-export current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
+current_dir := ${CURDIR}
+TOP := top
+SOURCES := ${current_dir}/counter.v
 
-export TOP := top
-export SOURCES := ${current_dir}/counter.v
+ifeq ($(TARGET),arty_35)
+  DEVICE := xc7a50t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a35tcsg324-1
+  XDC := ${current_dir}/arty.xdc
+else ifeq ($(TARGET),arty_100)
+  DEVICE := xc7a100t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a100tcsg324-1
+  XDC := ${current_dir}/arty.xdc
+else ifeq ($(TARGET),nexys4ddr)
+  DEVICE := xc7a100t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a100tcsg324-1
+  XDC := ${current_dir}/nexys4ddr.xdc
+else ifeq ($(TARGET),zybo)
+  DEVICE := xc7z010_test
+  BITSTREAM_DEVICE := zynq7
+  PARTNAME := xc7z010clg400-1
+  XDC := ${current_dir}/zybo.xdc
+  SOURCES:=${current_dir}/counter_zynq.v
+else ifeq ($(TARGET),nexys_video)
+  DEVICE := xc7a200t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a200tsbg484-1
+  XDC := ${current_dir}/nexys_video.xdc
+else
+  DEVICE := xc7a50t_test
+  BITSTREAM_DEVICE := artix7
+  PARTNAME := xc7a35tcpg236-1
+  XDC := ${current_dir}/basys3.xdc
+endif
+
+export
 
 all:
 	cd ../../common && $(MAKE)
-
 clean:
 	cd ../../common && $(MAKE) clean    
 

--- a/xc7/counter_test/Makefile
+++ b/xc7/counter_test/Makefile
@@ -3,35 +3,17 @@ TOP := top
 SOURCES := ${current_dir}/counter.v
 
 ifeq ($(TARGET),arty_35)
-  DEVICE := xc7a50t_test
-  BITSTREAM_DEVICE := artix7
-  PARTNAME := xc7a35tcsg324-1
   XDC := ${current_dir}/arty.xdc
 else ifeq ($(TARGET),arty_100)
-  DEVICE := xc7a100t_test
-  BITSTREAM_DEVICE := artix7
-  PARTNAME := xc7a100tcsg324-1
   XDC := ${current_dir}/arty.xdc
 else ifeq ($(TARGET),nexys4ddr)
-  DEVICE := xc7a100t_test
-  BITSTREAM_DEVICE := artix7
-  PARTNAME := xc7a100tcsg324-1
   XDC := ${current_dir}/nexys4ddr.xdc
 else ifeq ($(TARGET),zybo)
-  DEVICE := xc7z010_test
-  BITSTREAM_DEVICE := zynq7
-  PARTNAME := xc7z010clg400-1
   XDC := ${current_dir}/zybo.xdc
   SOURCES:=${current_dir}/counter_zynq.v
 else ifeq ($(TARGET),nexys_video)
-  DEVICE := xc7a200t_test
-  BITSTREAM_DEVICE := artix7
-  PARTNAME := xc7a200tsbg484-1
   XDC := ${current_dir}/nexys_video.xdc
 else
-  DEVICE := xc7a50t_test
-  BITSTREAM_DEVICE := artix7
-  PARTNAME := xc7a35tcpg236-1
   XDC := ${current_dir}/basys3.xdc
 endif
 

--- a/xc7/linux_litex_demo/Makefile
+++ b/xc7/linux_litex_demo/Makefile
@@ -2,9 +2,7 @@ current_dir := ${CURDIR}
 TOP := top
 SOURCES := ${current_dir}/baselitex_arty.v \
            ${current_dir}/VexRiscv_Linux.v
-MEM_INIT := ${current_dir}/mem.init \
-            ${current_dir}/mem_1.init \
-            ${current_dir}/mem_2.init
+
 PCF := ${current_dir}/arty.pcf
 SDC := ${current_dir}/arty.sdc
 XDC := ${current_dir}/arty.xdc

--- a/xc7/linux_litex_demo/Makefile
+++ b/xc7/linux_litex_demo/Makefile
@@ -9,17 +9,6 @@ PCF := ${current_dir}/arty.pcf
 SDC := ${current_dir}/arty.sdc
 XDC := ${current_dir}/arty.xdc
 
-
-BITSTREAM_DEVICE := artix7
-
-ifeq ($(TARGET),arty_100)
-    PARTNAME := xc7a100tcsg324-1
-    DEVICE   := xc7a100t_test
-else
-    PARTNAME := xc7a35tcsg324-1
-    DEVICE   := xc7a50t_test
-endif
-
 export
 
 all:

--- a/xc7/linux_litex_demo/Makefile
+++ b/xc7/linux_litex_demo/Makefile
@@ -9,10 +9,4 @@ PCF := ${current_dir}/arty.pcf
 SDC := ${current_dir}/arty.sdc
 XDC := ${current_dir}/arty.xdc
 
-export
-
-all:
-	cd ../../common && $(MAKE)
-
-clean:
-	cd ../../common && $(MAKE) clean    
+include ${current_dir}/../../common/Makefile 

--- a/xc7/linux_litex_demo/Makefile
+++ b/xc7/linux_litex_demo/Makefile
@@ -1,53 +1,29 @@
-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
+current_dir := ${CURDIR}
 TOP := top
-VERILOG := ${current_dir}/baselitex_arty.v \
+SOURCES := ${current_dir}/baselitex_arty.v \
            ${current_dir}/VexRiscv_Linux.v
 MEM_INIT := ${current_dir}/mem.init \
             ${current_dir}/mem_1.init \
             ${current_dir}/mem_2.init
-BITSTREAM_DEVICE := artix7
 PCF := ${current_dir}/arty.pcf
 SDC := ${current_dir}/arty.sdc
 XDC := ${current_dir}/arty.xdc
-BUILDDIR := build
+
+
+BITSTREAM_DEVICE := artix7
 
 ifeq ($(TARGET),arty_100)
     PARTNAME := xc7a100tcsg324-1
     DEVICE   := xc7a100t_test
-    BOARD_BUILDDIR := ${BUILDDIR}/arty_100
 else
     PARTNAME := xc7a35tcsg324-1
     DEVICE   := xc7a50t_test
-    BOARD_BUILDDIR := ${BUILDDIR}/arty_35
 endif
 
-.DELETE_ON_ERROR:
+export
 
-
-all: ${BOARD_BUILDDIR}/${TOP}.bit
-
-${BOARD_BUILDDIR}:
-	mkdir -p ${BOARD_BUILDDIR}
-	ln -s ${MEM_INIT} ${BOARD_BUILDDIR}
-
-${BOARD_BUILDDIR}/${TOP}.eblif: | ${BOARD_BUILDDIR}
-	cd ${BOARD_BUILDDIR} && symbiflow_synth -t ${TOP} -v ${VERILOG} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} -x ${XDC} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.net: ${BOARD_BUILDDIR}/${TOP}.eblif
-	cd ${BOARD_BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.place: ${BOARD_BUILDDIR}/${TOP}.net
-	cd ${BOARD_BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -p ${PCF} -n ${TOP}.net -P ${PARTNAME} -s ${SDC} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.route: ${BOARD_BUILDDIR}/${TOP}.place
-	cd ${BOARD_BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.fasm: ${BOARD_BUILDDIR}/${TOP}.route
-	cd ${BOARD_BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE}
-
-${BOARD_BUILDDIR}/${TOP}.bit: ${BOARD_BUILDDIR}/${TOP}.fasm
-	cd ${BOARD_BUILDDIR} && symbiflow_write_bitstream -d ${BITSTREAM_DEVICE} -f ${TOP}.fasm -p ${PARTNAME} -b ${TOP}.bit
+all:
+	cd ../../common && $(MAKE)
 
 clean:
-	rm -rf ${BUILDDIR}
+	cd ../../common && $(MAKE) clean    

--- a/xc7/picosoc_demo/Makefile
+++ b/xc7/picosoc_demo/Makefile
@@ -1,66 +1,39 @@
-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
+current_dir := ${CURDIR}
 TOP := top
-VERILOG := ${current_dir}/picosoc_noflash.v \
+SOURCES := ${current_dir}/picosoc_noflash.v \
            ${current_dir}/picorv32.v \
            ${current_dir}/simpleuart.v \
            ${current_dir}/progmem.v
-PARTNAME := xc7a35tcpg236-1
-DEVICE  := xc7a50t_test
-BITSTREAM_DEVICE := artix7
-PCF := ${current_dir}/basys3.pcf
+
 SDC := ${current_dir}/picosoc.sdc
-BUILDDIR := build
+BITSTREAM_DEVICE := artix7
 
 ifeq ($(TARGET),arty_35)
-  VERILOG += ${current_dir}/arty.v
+  DEVICE  := xc7a50t_test
+  SOURCES += ${current_dir}/arty.v
   PARTNAME := xc7a35tcsg324-1
   PCF := ${current_dir}/arty.pcf
-  BOARD_BUILDDIR := ${BUILDDIR}/arty_35
 else ifeq ($(TARGET),arty_100)
-  VERILOG += ${current_dir}/arty.v
-  PARTNAME := xc7a100tcsg324-1
-  PCF:=${current_dir}/arty.pcf
   DEVICE := xc7a100t_test
-  BOARD_BUILDDIR := ${BUILDDIR}/arty_100
+  SOURCES += ${current_dir}/arty.v
+  PARTNAME := xc7a100tcsg324-1
+  PCF := ${current_dir}/arty.pcf
 else ifeq ($(TARGET),nexys4ddr)
-  VERILOG += ${current_dir}/nexys4ddr.v
+  DEVICE := xc7a100t_test  
+  SOURCES += ${current_dir}/nexys4ddr.v
   PARTNAME := xc7a100tcsg324-1
-  PCF:=${current_dir}/nexys4ddr.pcf
-  DEVICE := xc7a100t_test
-  BOARD_BUILDDIR := ${BUILDDIR}/nexys4ddr
+  PCF := ${current_dir}/nexys4ddr.pcf
 else
-  VERILOG += ${current_dir}/basys3.v
+  DEVICE  := xc7a50t_test
+  SOURCES += ${current_dir}/basys3.v
   PARTNAME := xc7a35tcpg236-1
   PCF := ${current_dir}/basys3.pcf
-  BOARD_BUILDDIR := ${BUILDDIR}/basys3
 endif
 
-.DELETE_ON_ERROR:
+export
 
-
-all: ${BOARD_BUILDDIR}/${TOP}.bit
-
-${BOARD_BUILDDIR}:
-	mkdir -p ${BOARD_BUILDDIR}
-
-${BOARD_BUILDDIR}/${TOP}.eblif: | ${BOARD_BUILDDIR}
-	cd ${BOARD_BUILDDIR} && symbiflow_synth -t ${TOP} -v ${VERILOG} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.net: ${BOARD_BUILDDIR}/${TOP}.eblif
-	cd ${BOARD_BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.place: ${BOARD_BUILDDIR}/${TOP}.net
-	cd ${BOARD_BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -p ${PCF} -n ${TOP}.net -P ${PARTNAME} -s ${SDC} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.route: ${BOARD_BUILDDIR}/${TOP}.place
-	cd ${BOARD_BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 > /dev/null
-
-${BOARD_BUILDDIR}/${TOP}.fasm: ${BOARD_BUILDDIR}/${TOP}.route
-	cd ${BOARD_BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE}
-
-${BOARD_BUILDDIR}/${TOP}.bit: ${BOARD_BUILDDIR}/${TOP}.fasm
-	cd ${BOARD_BUILDDIR} && symbiflow_write_bitstream -d ${BITSTREAM_DEVICE} -f ${TOP}.fasm -p ${PARTNAME} -b ${TOP}.bit
+all:
+	cd ../../common && $(MAKE)
 
 clean:
-	rm -rf ${BUILDDIR}
+	cd ../../common && $(MAKE) clean 

--- a/xc7/picosoc_demo/Makefile
+++ b/xc7/picosoc_demo/Makefile
@@ -21,10 +21,4 @@ else
   PCF := ${current_dir}/basys3.pcf
 endif
 
-export
-
-all:
-	cd ../../common && $(MAKE)
-
-clean:
-	cd ../../common && $(MAKE) clean 
+include ${current_dir}/../../common/Makefile

--- a/xc7/picosoc_demo/Makefile
+++ b/xc7/picosoc_demo/Makefile
@@ -6,27 +6,18 @@ SOURCES := ${current_dir}/picosoc_noflash.v \
            ${current_dir}/progmem.v
 
 SDC := ${current_dir}/picosoc.sdc
-BITSTREAM_DEVICE := artix7
 
 ifeq ($(TARGET),arty_35)
-  DEVICE  := xc7a50t_test
   SOURCES += ${current_dir}/arty.v
-  PARTNAME := xc7a35tcsg324-1
   PCF := ${current_dir}/arty.pcf
 else ifeq ($(TARGET),arty_100)
-  DEVICE := xc7a100t_test
   SOURCES += ${current_dir}/arty.v
-  PARTNAME := xc7a100tcsg324-1
   PCF := ${current_dir}/arty.pcf
 else ifeq ($(TARGET),nexys4ddr)
-  DEVICE := xc7a100t_test  
   SOURCES += ${current_dir}/nexys4ddr.v
-  PARTNAME := xc7a100tcsg324-1
   PCF := ${current_dir}/nexys4ddr.pcf
 else
-  DEVICE  := xc7a50t_test
   SOURCES += ${current_dir}/basys3.v
-  PARTNAME := xc7a35tcpg236-1
   PCF := ${current_dir}/basys3.pcf
 endif
 


### PR DESCRIPTION
In response to the comments made by @acomodi and @kgugala  in [PR #167](https://github.com/SymbiFlow/symbiflow-examples/pull/167#discussion_r684103579), this PR moves the redundant pieces of the Makefiles throughout symbiflow-examples into a separate common Makefile that each design calls. For the common Makefile to work a user should specify the name of their target device (i.e. basys3, arty_35, zybo, etc.), the name of their top level module, their HDL design sources, any memory initialization files, and what constraint files they are using before calling the common Makefile. The common Makefile will take care of setting the various board parameters, as well as running the commands to build the design. I also added error checking for unsupported board types to the common makefile.   
I decided to have the common makefile control the board parameters because I think it makes the example design if/else blocks more clean. This method also makes it simpler for a user to build on the common makefile. Users only need to specify their target board type, HDL design sources, name of top level module, and constraint files in order to build there own designs instead of having to worry about getting the correct part names for their board.