### PR TITLE
Fix for eos-s3 FASM generation error

### DIFF
--- a/eos-s3/requirements.txt
+++ b/eos-s3/requirements.txt
@@ -1,3 +1,3 @@
 python-constraint
 serial
-git+https://github.com/QuickLogic-Corp/quicklogic-fasm
+git+https://github.com/QuickLogic-Corp/quicklogic-fasm@57b6e60574a9d483dc94710d0d3ff42a62b4ec41


### PR DESCRIPTION
This PR pins the `quicklogic_fasm` version used by the toolchain to avoid incompatibilities throughout its development.