### PR TITLE
getting-symbiflow.rst: Clarified download location

### DIFF
--- a/docs/getting-symbiflow.rst
+++ b/docs/getting-symbiflow.rst
@@ -57,7 +57,7 @@ into three steps:
 Conda
 ~~~~~
 
-Download Conda installer script:
+Download Conda installer script into the symbiflow-examples directory:
 
 .. code-block:: bash
    :name: wget-conda


### PR DESCRIPTION
Clarifies that the conda_installer.sh script should be downloaded into
the git repository.

By habit, I place downloaded scripts into the ~/Downloads directory, and
avoid adding non-repo files to repositories. However, when I did that I
ended up with some difficult to diagnose bugs several steps later. It
was only on carefully rereading the instructions I realized what I ought
to have done. The intention of this change is to make clear to other new
users that they ought to place conda_installer.sh into the git repo
directory.

Signed-off-by: Alan Green <alan.green@gmail.com>