### PR TITLE
ci: add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 99


### PR DESCRIPTION
This PR adds a dependabot configuration file. Dependabot is a built-in service from GitHub which will create PRs for updating GitHub Actions.