### PR TITLE
docs: update xc7 arch-def tarball URLs to '*-latest'

### DIFF
--- a/.github/scripts/install-toolchain.sh
+++ b/.github/scripts/install-toolchain.sh
@@ -45,4 +45,4 @@ fi
 fpga_family=$1
 os=$2
 
-tuttest_exec docs/getting-symbiflow.rst:install-reqs-$os,wget-conda,conda-install-dir,fpga-fam-$fpga_family,conda-setup,download-arch-def-$fpga_family
+tuttest_exec docs/getting-symbiflow.rst:install-reqs-$os,curl-conda,conda-install-dir,fpga-fam-$fpga_family,conda-setup,download-arch-def-$fpga_family

--- a/docs/getting-symbiflow.rst
+++ b/docs/getting-symbiflow.rst
@@ -17,7 +17,7 @@ To be able to follow through this tutorial, install the following software:
          :name: install-reqs-ubuntu
 
          apt update -y
-         apt install -y git wget xz-utils
+         apt install -y git curl xz-utils
 
    .. group-tab:: Debian
 
@@ -25,7 +25,7 @@ To be able to follow through this tutorial, install the following software:
          :name: install-reqs-debian
 
          apt update -y
-         apt install -y git wget xz-utils
+         apt install -y git curl xz-utils
 
    .. group-tab:: CentOS
 
@@ -33,7 +33,7 @@ To be able to follow through this tutorial, install the following software:
          :name: install-reqs-centos
 
          yum update -y
-         yum install -y git wget which xz
+         yum install -y git curl which xz
 
    .. group-tab:: Fedora
 
@@ -67,9 +67,9 @@ Conda
 Download Conda installer script into the symbiflow-examples directory:
 
 .. code-block:: bash
-   :name: wget-conda
+   :name: curl-conda
 
-   wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda_installer.sh
+   curl -fsSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > conda_installer.sh
 
 Choose the install directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -124,18 +124,16 @@ Download architecture definitions:
          :name: download-arch-def-xc7
 
          mkdir -p $INSTALL_DIR/xc7/install
-         wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/459/20211116-000105/symbiflow-arch-defs-install-ef6fff3c.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
-         wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/459/20211116-000105/symbiflow-arch-defs-xc7a50t_test-ef6fff3c.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
-         wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/459/20211116-000105/symbiflow-arch-defs-xc7a100t_test-ef6fff3c.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
-         wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/459/20211116-000105/symbiflow-arch-defs-xc7a200t_test-ef6fff3c.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
-         wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/459/20211116-000105/symbiflow-arch-defs-xc7z010_test-ef6fff3c.tar.xz | tar -xJC $INSTALL_DIR/xc7/install
+         for PKG in toolchain xc7a50t_test xc7a100t_test xc7a200t_test xc7z010_test xc7z020_test; do
+           curl -fsSL "https://storage.googleapis.com/symbiflow-arch-defs-gha/symbiflow-${PKG}-latest" | xargs curl -fsSL | tar -xJC "$INSTALL_DIR/xc7/install"
+         done
 
    .. group-tab:: EOS-S3
 
       .. code-block:: bash
          :name: download-arch-def-eos-s3
 
-         wget -qO- https://storage.googleapis.com/symbiflow-arch-defs-install/quicklogic-arch-defs-63c3d8f9.tar.gz | tar -xz -C $INSTALL_DIR/eos-s3/
+         curl -fsSL https://storage.googleapis.com/symbiflow-arch-defs-install/quicklogic-arch-defs-63c3d8f9.tar.gz | tar -xzC $INSTALL_DIR/eos-s3/
 
 If the above commands exited without errors, you have successfully installed and configured your working environment.
 

--- a/docs/running-examples.rst
+++ b/docs/running-examples.rst
@@ -157,7 +157,7 @@ Prepare SD card
 
       mkdir uboot-linux-images
       pushd uboot-linux-images
-      wget -qO- https://github.com/SymbiFlow/symbiflow-xc7z-automatic-tester/releases/download/v1.0.0/uboot-linux-images.zip | bsdtar -xf-
+      curl -fsSL https://github.com/SymbiFlow/symbiflow-xc7z-automatic-tester/releases/download/v1.0.0/uboot-linux-images.zip | bsdtar -xf-
       popd
 
 #. Copy U-boot images to the boot mountpoint:
@@ -171,7 +171,7 @@ Prepare SD card
 
    .. code-block:: bash
 
-      wget -qO- http://de5.mirror.archlinuxarm.org/os/ArchLinuxARM-armv7-latest.tar.gz | sudo tar -xvzC /path/to/mountpoint/root
+      curl -fsSL http://de5.mirror.archlinuxarm.org/os/ArchLinuxARM-armv7-latest.tar.gz | sudo tar -xvzC /path/to/mountpoint/root
       sync
 
 #. Copy additional files and binaries to the root directory in the Arch Linux filesystem:
@@ -201,7 +201,7 @@ Load bitstreams from U-boot
 Make sure to have :ref:`prepared the SD correctly<prepare-sd>`.
 
 #. With the SD card inserted in the PC, copy the bitstream in the boot directory:
-   
+
    .. code-block:: bash
 
       cp <name>.bit /path/to/mountpoint/boot


### PR DESCRIPTION
Close #83.

Ref #115.

This PR updates the URLs to download latest arch-def packages for xc7 devices. By the way, xc7z020_test is added.

/cc @mithro