### PR TITLE
Document the prerequisites on Fedora, and test in CI

### DIFF
--- a/.github/scripts/generate_job_matrix.py
+++ b/.github/scripts/generate_job_matrix.py
@@ -33,7 +33,8 @@ osvers = [
     ("centos", "8"),
     ("debian", "buster"),
     ("debian", "bullseye"),
-    ("debian", "sid")
+    ("debian", "sid"),
+    ("fedora", "35")
 ]
 
 for osver in osvers:

--- a/.github/workflows/sphinx-tuttest.yml
+++ b/.github/workflows/sphinx-tuttest.yml
@@ -40,6 +40,7 @@ jobs:
     container: ${{matrix.os}}:${{matrix.os-version}}
 
     steps:
+
       - name: Setup repository
         uses: actions/checkout@v2
         with:
@@ -52,6 +53,10 @@ jobs:
       - name: Install utils
         if: ${{matrix.os == 'centos'}}
         run: yum -y install wget
+
+      - name: Install utils
+        if: ${{matrix.os == 'fedora'}}
+        run: dnf install -y wget
 
       - name: Install tuttest
         run: |

--- a/docs/getting-symbiflow.rst
+++ b/docs/getting-symbiflow.rst
@@ -35,6 +35,13 @@ To be able to follow through this tutorial, install the following software:
          yum update -y
          yum install -y git wget which xz
 
+   .. group-tab:: Fedora
+
+      .. code-block:: bash
+         :name: install-reqs-fedora
+
+         dnf install -y findutils git wget which xz
+
 
 Next, clone the SymbiFlow examples repository and enter it:
 


### PR DESCRIPTION
As per #30, this PR add 'Fedora latest' to the list of OS used in CI.