### PR TITLE
ci: use default runners when running CI on a fork

### DIFF
--- a/.github/scripts/generate_job_matrix.py
+++ b/.github/scripts/generate_job_matrix.py
@@ -11,11 +11,9 @@ runs_on = (
 )
 
 examples = [
-    "counter",
     "picosoc",
     "litex",
     "litex_linux",
-    "litex_sata",
     "button_controller",
     "pulse_width_led",
     "timer",
@@ -45,6 +43,10 @@ osvers = [
 ]
 
 if not isFork:
+    examples = [
+        "counter",
+        "litex_sata",
+    ] + examples
     osvers += [
         ("ubuntu", "xenial"),
         ("ubuntu", "bionic"),

--- a/.github/scripts/generate_job_matrix.py
+++ b/.github/scripts/generate_job_matrix.py
@@ -2,9 +2,11 @@
 
 from sys import argv as sys_argv
 
+isFork = len(sys_argv)>1 and sys_argv[1] != 'SymbiFlow/symbiflow-examples'
+
 runs_on = (
     'ubuntu-latest'
-    if len(sys_argv)>1 and sys_argv[1] != 'SymbiFlow/symbiflow-examples' else
+    if isFork else
     ['self-hosted', 'Linux', 'X64']
 )
 
@@ -34,16 +36,20 @@ examples = [
 jobs = []
 
 osvers = [
-    ("ubuntu", "xenial"),
-    ("ubuntu", "bionic"),
     ("ubuntu", "focal"),
-    ("centos", "7"),
     ("centos", "8"),
     ("debian", "buster"),
     ("debian", "bullseye"),
     ("debian", "sid"),
     ("fedora", "35")
 ]
+
+if not isFork:
+    osvers += [
+        ("ubuntu", "xenial"),
+        ("ubuntu", "bionic"),
+        ("centos", "7"),
+    ]
 
 for osver in osvers:
     jobs += [{

--- a/.github/scripts/generate_job_matrix.py
+++ b/.github/scripts/generate_job_matrix.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
 
+from sys import argv as sys_argv
+
+runs_on = (
+    'ubuntu-latest'
+    if len(sys_argv)>1 and sys_argv[1] != 'SymbiFlow/symbiflow-examples' else
+    ['self-hosted', 'Linux', 'X64']
+)
+
 examples = [
     "counter",
     "picosoc",
@@ -39,6 +47,7 @@ osvers = [
 
 for osver in osvers:
     jobs += [{
+        'runs-on': runs_on,
         'fpga-fam': "xc7",
         'os': osver[0],
         'os-version': osver[1],
@@ -46,10 +55,13 @@ for osver in osvers:
     } for example in examples]
 
 jobs += [{
+    'runs-on': runs_on,
     'fpga-fam': "eos-s3",
     'os': osver[0],
     'os-version': osver[1],
     'example': "counter"
 } for osver in osvers]
 
-print('::set-output name=matrix::' + str(jobs))
+print(f'::set-output name=matrix::{jobs!s}')
+
+print(str(jobs))

--- a/.github/workflows/sphinx-tuttest.yml
+++ b/.github/workflows/sphinx-tuttest.yml
@@ -21,16 +21,17 @@ jobs:
 
       - name: Generate examples matrix
         id: generate
-        run: ./.github/scripts/generate_job_matrix.py
+        run: ./.github/scripts/generate_job_matrix.py '${{ github.repository }}'
 
 
   Test:
     needs: Matrix
-    runs-on: [self-hosted, Linux, X64]
     strategy:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.Matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.runs-on }}
+    name: ${{ matrix.fpga-fam }} | ${{ matrix.os }} ${{ matrix.os-version }} | ${{ matrix.example }}
 
     env:
       LANG: "en_US.UTF-8"


### PR DESCRIPTION
Currently, the CI workflow expects self-hosted runners to exist. Therefore, it does not work on forks of this repo. This PR adds a condition in `generate_job_matrix.py` in order to change between `ubuntu-latest` and the self-hosted runners depending on the `github.repository` context value. Moreover, the set of tests to be executed on forks is reduced.