### PR TITLE
ci: install 'git' in the containers before cloning the repo

### DIFF
--- a/.github/workflows/sphinx-tuttest.yml
+++ b/.github/workflows/sphinx-tuttest.yml
@@ -41,15 +41,9 @@ jobs:
     container: ${{matrix.os}}:${{matrix.os-version}}
 
     steps:
-
-      - name: Setup repository
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
       - name: Install utils
         if: ${{matrix.os == 'ubuntu' || matrix.os == 'debian'}}
-        run: apt -qqy update && apt -qqy install wget locales && locale-gen $LANG
+        run: apt -qqy update && apt -qqy install git wget locales && locale-gen $LANG
 
       - name: Install utils
         if: ${{matrix.os == 'centos' && matrix.os-version == '8'}}
@@ -59,12 +53,16 @@ jobs:
 
       - name: Install utils
         if: ${{matrix.os == 'centos'}}
-        run: |
-          yum -y install wget
+        run: yum -y install git wget
 
       - name: Install utils
         if: ${{matrix.os == 'fedora'}}
-        run: dnf install -y wget
+        run: dnf install -y git wget
+
+      - name: Setup repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Install tuttest
         run: |


### PR DESCRIPTION
This PR install `git` on the containers before using `actions/checkout`, instead of doing it afterwards.

On the one hand, we are already installing git later in each job, because the prerequisites in the docs include git. Therefore, this is just doing it before.

On the other hand, `actions/checkout` will fall back to the GitHub API if `git` is not found. Currently, this repo uses "Container jobs", which means that all the steps of the job are executed inside the container. Therefore, if `git` is not found, the Action uses the API, and that is undesirable because some features such as option `submodules` might not work. See:

> https://github.com/actions/checkout/#whats-new
> Fallback to REST API download
>
> * When Git 2.18 or higher is not in the PATH, the REST API will be used to download the files
> * When using a job container, the container's PATH is used

In fact, the warning/error is not produced when using the self-hosted runners in this repo. I found this when I used the default runners in my fork. I wonder if the Antmicro runner is doing something different in this regard, or whether it's inherited from GitHub's self-hosted runner codebase.

- Without this PR: https://github.com/umarcor/symbiflow-examples/actions/runs/1606846683
- With this PR: https://github.com/umarcor/symbiflow-examples/actions/runs/1606879598

Ref: #228