### PR TITLE
common/common.mk: strip extra spaces from variables and fix dependencies

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -1,3 +1,6 @@
+TOP := $(strip ${TOP})
+TARGET := $(strip ${TARGET})
+
 BUILDDIR := ${current_dir}/build
 BOARD_BUILDDIR := ${BUILDDIR}/${TARGET}
 

--- a/common/common.mk
+++ b/common/common.mk
@@ -49,7 +49,7 @@ all: ${BOARD_BUILDDIR}/${TOP}.bit
 ${BOARD_BUILDDIR}:
 	mkdir -p ${BOARD_BUILDDIR}
 
-${BOARD_BUILDDIR}/${TOP}.eblif: | ${BOARD_BUILDDIR}
+${BOARD_BUILDDIR}/${TOP}.eblif: ${SOURCES} ${XDC} ${SDC} ${PCF} | ${BOARD_BUILDDIR}
 	cd ${BOARD_BUILDDIR} && symbiflow_synth -t ${TOP} -v ${SOURCES} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} ${XDC_CMD} 2>&1 > /dev/null
 
 ${BOARD_BUILDDIR}/${TOP}.net: ${BOARD_BUILDDIR}/${TOP}.eblif


### PR DESCRIPTION
TOP and TARGET require no extra spaces - add code to strip them out.

The .eblif dependencies should include sources, and constraints files.