### PR TITLE
Strip whitespace from variable definitions in common/common.mk

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -1,3 +1,6 @@
+TOP := $(strip ${TOP})
+TARGET := $(strip ${TARGET})
+
 BUILDDIR := ${current_dir}/build
 BOARD_BUILDDIR := ${BUILDDIR}/${TARGET}
 


### PR DESCRIPTION
Trailing whitespace in variable defs causes compile errrors.  This strips it out.

Signed-off-by: Brent Nelson <nelson@ee.byu.edu>