### PR TITLE
ci: test on Fedora 36

### DIFF
--- a/.github/scripts/generate_job_matrix.py
+++ b/.github/scripts/generate_job_matrix.py
@@ -55,7 +55,8 @@ osvers = [
     ("debian", "buster"),
     ("debian", "bullseye"),
     ("debian", "sid"),
-    ("fedora", "35")
+    ("fedora", "35"),
+    ("fedora", "36"),
 ]
 
 if not isFork:


### PR DESCRIPTION
A couple of months ago, Fedora 36 was failing, so we added Fedora 35 only (see #228). It seems that Fedora 36 is working now, so this PR adds it to the matrix.