### PR TITLE
readthedocs: quote python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,6 +26,6 @@ sphinx:
   fail_on_warning: true
 
 python:
-  version: 3.7
+  version: "3.7"
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
See https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version-legacy and SymbiFlow/symbiflow-arch-defs#2415.